### PR TITLE
Fix invalid action version

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Add activity to readme
-        uses: Readme-Workflows/recent-activity@v1
+        uses: Readme-Workflows/recent-activity@v1.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
V1 is not an available release of the recent-activity action and GitHub does to my knowledge not support shortcuts (i.e. v1 for latest v1.x release)